### PR TITLE
help text, hide password, translate timezones, add date to track

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ejs": "~2.3.3",
     "express": "~4.13.1",
     "moment": "^2.12.0",
+    "moment-timezone": "^0.5.3",
     "mongodb": "^1.4.40",
     "monk": "^1.0.1",
     "morgan": "~1.6.1",


### PR DESCRIPTION
codemill-id-56f91ed63c43fb0300541e4d fixes #6

Okay, so a few things need mentioning:

1) I added `moment-timezone` as a dependency in `package.json` to assist in translating from your local timezone to Anuko's [GMT] timezone.

2) I added the ability to set LOCAL_TIMEZONE and ANUKO_TIMEZONE in the environment and this will make use of it, otherwise it defaults to "Asia/Jerusalem" for the local and "GMT" for Anuko.

3) Because I used "Asia/Jerusalem" rather than "IDT" or "IST" it should automatically track daylight savings time. :smile:

4) I found a bug!  In my original contribution I cleared the "in-time" on both `/ttt out` and `/ttt track ...`.  I don't think this was correct.  As far as I know, `/ttt track ...` is issued unrelated to the current task.  It would be wrong to clear the 'in-time' of the current task if you're registering a separate task.  Correct?  I have added a new check to make sure it only clears the in-time in the Mongo database if you're doing `/ttt out`

5) This took me a while to test - I was confusing myself.  I was translating the date argument from local to "Anuko time" and it was making "2016-03-28" become "2016-03-27".  I didn't think it was registering the task because I was viewing 3/28, not 3/27.

Anyway, I hope this is everything you were looking for.  Please let me know if you need me to fix something! :smile:
